### PR TITLE
Refactor linux build script and add basic gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.swp
+*.bak
+**/o/
+signalbackup-tools

--- a/BUILDSCRIPT.sh
+++ b/BUILDSCRIPT.sh
@@ -1,105 +1,52 @@
 #!/bin/sh
+set -o errexit
+set -o nounset
+set -o pipefail
 
 COMPILER=$(which g++)
-if [ -z "$COMPILER" ] ; then echo "Failed to find g++ binary" && exit 1 ; fi
-NUMCPU=$(nproc)
-if [ -z "$NUMCPU" ] ; then NUMCPU=1 ; fi
+NUMCPU=$(nproc || echo 1)
 
-echo -E "BUILDING (1/24): $COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o \"cryptbase/o/cryptbase.o\" \"cryptbase/cryptbase.cc\""
-if [ ! -d "cryptbase/o" ] ; then mkdir "cryptbase/o" ; fi
-$COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o "cryptbase/o/cryptbase.o" "cryptbase/cryptbase.cc"
-if [ $? -ne 0 ] ; then exit 1 ; fi
-echo -E "BUILDING (2/24): $COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o \"cryptbase/o/getbackupkey.o\" \"cryptbase/getbackupkey.cc\""
-if [ ! -d "cryptbase/o" ] ; then mkdir "cryptbase/o" ; fi
-$COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o "cryptbase/o/getbackupkey.o" "cryptbase/getbackupkey.cc"
-if [ $? -ne 0 ] ; then exit 1 ; fi
-echo -E "BUILDING (3/24): $COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o \"cryptbase/o/getcipherandmac.o\" \"cryptbase/getcipherandmac.cc\""
-if [ ! -d "cryptbase/o" ] ; then mkdir "cryptbase/o" ; fi
-$COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o "cryptbase/o/getcipherandmac.o" "cryptbase/getcipherandmac.cc"
-if [ $? -ne 0 ] ; then exit 1 ; fi
-echo -E "BUILDING (4/24): $COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o \"endframe/o/statics.o\" \"endframe/statics.cc\""
-if [ ! -d "endframe/o" ] ; then mkdir "endframe/o" ; fi
-$COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o "endframe/o/statics.o" "endframe/statics.cc"
-if [ $? -ne 0 ] ; then exit 1 ; fi
-echo -E "BUILDING (5/24): $COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o \"filedecryptor/o/getframe.o\" \"filedecryptor/getframe.cc\""
-if [ ! -d "filedecryptor/o" ] ; then mkdir "filedecryptor/o" ; fi
-$COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o "filedecryptor/o/getframe.o" "filedecryptor/getframe.cc"
-if [ $? -ne 0 ] ; then exit 1 ; fi
-echo -E "BUILDING (6/24): $COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o \"filedecryptor/o/initbackupframe.o\" \"filedecryptor/initbackupframe.cc\""
-if [ ! -d "filedecryptor/o" ] ; then mkdir "filedecryptor/o" ; fi
-$COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o "filedecryptor/o/initbackupframe.o" "filedecryptor/initbackupframe.cc"
-if [ $? -ne 0 ] ; then exit 1 ; fi
-echo -E "BUILDING (7/24): $COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o \"filedecryptor/o/getattachment.o\" \"filedecryptor/getattachment.cc\""
-if [ ! -d "filedecryptor/o" ] ; then mkdir "filedecryptor/o" ; fi
-$COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o "filedecryptor/o/getattachment.o" "filedecryptor/getattachment.cc"
-if [ $? -ne 0 ] ; then exit 1 ; fi
-echo -E "BUILDING (8/24): $COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o \"filedecryptor/o/filedecryptor.o\" \"filedecryptor/filedecryptor.cc\""
-if [ ! -d "filedecryptor/o" ] ; then mkdir "filedecryptor/o" ; fi
-$COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o "filedecryptor/o/filedecryptor.o" "filedecryptor/filedecryptor.cc"
-if [ $? -ne 0 ] ; then exit 1 ; fi
-echo -E "BUILDING (9/24): $COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o \"arg/o/arg.o\" \"arg/arg.cc\""
-if [ ! -d "arg/o" ] ; then mkdir "arg/o" ; fi
-$COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o "arg/o/arg.o" "arg/arg.cc"
-if [ $? -ne 0 ] ; then exit 1 ; fi
-echo -E "BUILDING (10/24): $COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o \"sharedprefframe/o/statics.o\" \"sharedprefframe/statics.cc\""
-if [ ! -d "sharedprefframe/o" ] ; then mkdir "sharedprefframe/o" ; fi
-$COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o "sharedprefframe/o/statics.o" "sharedprefframe/statics.cc"
-if [ $? -ne 0 ] ; then exit 1 ; fi
-echo -E "BUILDING (11/24): $COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o \"avatarframe/o/statics.o\" \"avatarframe/statics.cc\""
-if [ ! -d "avatarframe/o" ] ; then mkdir "avatarframe/o" ; fi
-$COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o "avatarframe/o/statics.o" "avatarframe/statics.cc"
-if [ $? -ne 0 ] ; then exit 1 ; fi
-echo -E "BUILDING (12/24): $COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o \"attachmentframe/o/statics.o\" \"attachmentframe/statics.cc\""
-if [ ! -d "attachmentframe/o" ] ; then mkdir "attachmentframe/o" ; fi
-$COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o "attachmentframe/o/statics.o" "attachmentframe/statics.cc"
-if [ $? -ne 0 ] ; then exit 1 ; fi
-echo -E "BUILDING (13/24): $COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o \"fileencryptor/o/encryptattachment.o\" \"fileencryptor/encryptattachment.cc\""
-if [ ! -d "fileencryptor/o" ] ; then mkdir "fileencryptor/o" ; fi
-$COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o "fileencryptor/o/encryptattachment.o" "fileencryptor/encryptattachment.cc"
-if [ $? -ne 0 ] ; then exit 1 ; fi
-echo -E "BUILDING (14/24): $COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o \"fileencryptor/o/encryptframe.o\" \"fileencryptor/encryptframe.cc\""
-if [ ! -d "fileencryptor/o" ] ; then mkdir "fileencryptor/o" ; fi
-$COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o "fileencryptor/o/encryptframe.o" "fileencryptor/encryptframe.cc"
-if [ $? -ne 0 ] ; then exit 1 ; fi
-echo -E "BUILDING (15/24): $COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o \"fileencryptor/o/fileencryptor.o\" \"fileencryptor/fileencryptor.cc\""
-if [ ! -d "fileencryptor/o" ] ; then mkdir "fileencryptor/o" ; fi
-$COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o "fileencryptor/o/fileencryptor.o" "fileencryptor/fileencryptor.cc"
-if [ $? -ne 0 ] ; then exit 1 ; fi
-echo -E "BUILDING (16/24): $COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o \"sqlstatementframe/o/statics.o\" \"sqlstatementframe/statics.cc\""
-if [ ! -d "sqlstatementframe/o" ] ; then mkdir "sqlstatementframe/o" ; fi
-$COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o "sqlstatementframe/o/statics.o" "sqlstatementframe/statics.cc"
-if [ $? -ne 0 ] ; then exit 1 ; fi
-echo -E "BUILDING (17/24): $COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o \"sqlstatementframe/o/buildstatement.o\" \"sqlstatementframe/buildstatement.cc\""
-if [ ! -d "sqlstatementframe/o" ] ; then mkdir "sqlstatementframe/o" ; fi
-$COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o "sqlstatementframe/o/buildstatement.o" "sqlstatementframe/buildstatement.cc"
-if [ $? -ne 0 ] ; then exit 1 ; fi
-echo -E "BUILDING (18/24): $COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o \"signalbackup/o/signalbackup.o\" \"signalbackup/signalbackup.cc\""
-if [ ! -d "signalbackup/o" ] ; then mkdir "signalbackup/o" ; fi
-$COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o "signalbackup/o/signalbackup.o" "signalbackup/signalbackup.cc"
-if [ $? -ne 0 ] ; then exit 1 ; fi
-echo -E "BUILDING (19/24): $COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o \"o/main.o\" \"main.cc\""
-if [ ! -d "o" ] ; then mkdir "o" ; fi
-$COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o "o/main.o" "main.cc"
-if [ $? -ne 0 ] ; then exit 1 ; fi
-echo -E "BUILDING (20/24): $COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o \"backupframe/o/init.o\" \"backupframe/init.cc\""
-if [ ! -d "backupframe/o" ] ; then mkdir "backupframe/o" ; fi
-$COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o "backupframe/o/init.o" "backupframe/init.cc"
-if [ $? -ne 0 ] ; then exit 1 ; fi
-echo -E "BUILDING (21/24): $COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o \"sqlitedb/o/sqlitedb.o\" \"sqlitedb/sqlitedb.cc\""
-if [ ! -d "sqlitedb/o" ] ; then mkdir "sqlitedb/o" ; fi
-$COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o "sqlitedb/o/sqlitedb.o" "sqlitedb/sqlitedb.cc"
-if [ $? -ne 0 ] ; then exit 1 ; fi
-echo -E "BUILDING (22/24): $COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o \"databaseversionframe/o/statics.o\" \"databaseversionframe/statics.cc\""
-if [ ! -d "databaseversionframe/o" ] ; then mkdir "databaseversionframe/o" ; fi
-$COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o "databaseversionframe/o/statics.o" "databaseversionframe/statics.cc"
-if [ $? -ne 0 ] ; then exit 1 ; fi
-echo -E "BUILDING (23/24): $COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o \"headerframe/o/statics.o\" \"headerframe/statics.cc\""
-if [ ! -d "headerframe/o" ] ; then mkdir "headerframe/o" ; fi
-$COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o "headerframe/o/statics.o" "headerframe/statics.cc"
-if [ $? -ne 0 ] ; then exit 1 ; fi
-echo -E "BUILDING (24/24): $COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o \"stickerframe/o/statics.o\" \"stickerframe/statics.cc\""
-if [ ! -d "stickerframe/o" ] ; then mkdir "stickerframe/o" ; fi
-$COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto -o "stickerframe/o/statics.o" "stickerframe/statics.cc"
-if [ $? -ne 0 ] ; then exit 1 ; fi
-echo -E "LINKING: $COMPILER -Wall -Wextra -Wl,-z,now -O3 -s -flto=$NUMCPU \"cryptbase/o/cryptbase.o\" \"cryptbase/o/getbackupkey.o\" \"cryptbase/o/getcipherandmac.o\" \"endframe/o/statics.o\" \"filedecryptor/o/getframe.o\" \"filedecryptor/o/initbackupframe.o\" \"filedecryptor/o/getattachment.o\" \"filedecryptor/o/filedecryptor.o\" \"arg/o/arg.o\" \"sharedprefframe/o/statics.o\" \"avatarframe/o/statics.o\" \"attachmentframe/o/statics.o\" \"fileencryptor/o/encryptattachment.o\" \"fileencryptor/o/encryptframe.o\" \"fileencryptor/o/fileencryptor.o\" \"sqlstatementframe/o/statics.o\" \"sqlstatementframe/o/buildstatement.o\" \"signalbackup/o/signalbackup.o\" \"o/main.o\" \"backupframe/o/init.o\" \"sqlitedb/o/sqlitedb.o\" \"databaseversionframe/o/statics.o\" \"headerframe/o/statics.o\" \"stickerframe/o/statics.o\" -lcryptopp -lsqlite3 -o \"signalbackup-tools\""
-$COMPILER -Wall -Wextra -Wl,-z,now -O3 -s -flto=$NUMCPU "cryptbase/o/cryptbase.o" "cryptbase/o/getbackupkey.o" "cryptbase/o/getcipherandmac.o" "endframe/o/statics.o" "filedecryptor/o/getframe.o" "filedecryptor/o/initbackupframe.o" "filedecryptor/o/getattachment.o" "filedecryptor/o/filedecryptor.o" "arg/o/arg.o" "sharedprefframe/o/statics.o" "avatarframe/o/statics.o" "attachmentframe/o/statics.o" "fileencryptor/o/encryptattachment.o" "fileencryptor/o/encryptframe.o" "fileencryptor/o/fileencryptor.o" "sqlstatementframe/o/statics.o" "sqlstatementframe/o/buildstatement.o" "signalbackup/o/signalbackup.o" "o/main.o" "backupframe/o/init.o" "sqlitedb/o/sqlitedb.o" "databaseversionframe/o/statics.o" "headerframe/o/statics.o" "stickerframe/o/statics.o" -lcryptopp -lsqlite3 -o "signalbackup-tools"
+BUILD_CMD="$COMPILER -std=c++2a -c -Wall -Wextra -Wshadow -Wold-style-cast -Woverloaded-virtual -pedantic -fomit-frame-pointer -O3 -march=native -flto"
+MODULES="cryptbase/cryptbase.cc
+cryptbase/getbackupkey.cc
+cryptbase/getcipherandmac.cc
+endframe/statics.cc
+filedecryptor/getframe.cc
+filedecryptor/initbackupframe.cc
+filedecryptor/getattachment.cc
+filedecryptor/filedecryptor.cc
+arg/arg.cc
+sharedprefframe/statics.cc
+avatarframe/statics.cc
+attachmentframe/statics.cc
+fileencryptor/encryptattachment.cc
+fileencryptor/encryptframe.cc
+fileencryptor/fileencryptor.cc
+sqlstatementframe/statics.cc
+sqlstatementframe/buildstatement.cc
+signalbackup/signalbackup.cc
+main.cc
+backupframe/init.cc
+sqlitedb/sqlitedb.cc
+databaseversionframe/statics.cc
+headerframe/statics.cc
+stickerframe/statics.cc"
+
+MODULE_COUNT=$(wc -l <<<"$MODULES")
+
+i=0
+while read module; do
+  i=$((i+1))
+  outdir="$(dirname $module)/o"
+  module_name=$(basename $module)
+  outfile="$outdir/${module_name%.cc}.o"
+
+  echo "BUILDING ($i/$MODULE_COUNT): $module_name -> $outfile"
+  mkdir -p $outdir
+  $BUILD_CMD -o "$outfile" "$module"
+  modules_out="${modules_out:-} $outfile"
+done <<<"$MODULES"
+
+echo "LINKING: signalbackup-tools"
+echo g++ -Wall -Wextra -Wl,-z,now -O3 -s -flto=$NUMCPU $modules_out -lcryptopp -lsqlite3 -o "signalbackup-tools"
+g++ -Wall -Wextra -Wl,-z,now -O3 -s -flto=$NUMCPU $modules_out -lcryptopp -lsqlite3 -o "signalbackup-tools"


### PR DESCRIPTION
The build script was hard to read, so I cleared it a little. It also creates the object folders (e.g. `cryptbase/o` when not present, which eases the first run. I also put them onto the ignore list, so that they're not checked in by accident.

This style has a little caveat that every module is build with the same command. Not sure if this plays a role, but if one module requires additional parameters in the future, it could just be built separately or so.