### PR TITLE
Add platform checks for macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 !*/*.h
 !*/*.ih
 !.gitignore
+.ccls-cache/

--- a/common_be.h
+++ b/common_be.h
@@ -32,7 +32,7 @@
 #include <cstring>
 #include <algorithm>
 
-#if defined(__linux__) && !defined(__MINGW64__)
+#if (defined(__linux__) || (defined(__APPLE__) && defined(__MACH__))) && !defined(__MINGW64__)
 #include <sys/ioctl.h>
   #if __has_include("unistd.h")
   #define HAS_UNISTD_H_

--- a/main.h
+++ b/main.h
@@ -22,7 +22,7 @@
 
 #include <string>
 
-#if defined(__linux__) && !defined(__MINGW64__)
+#if (defined(__linux__) || (defined(__APPLE__) && defined(__MACH__))) && !defined(__MINGW64__)
 #include <unistd.h>
 #include <termios.h>
 #endif
@@ -37,7 +37,7 @@ inline bool getPassword(std::string *pw)
   if (!pw)
     return false;
 
-#if defined(__linux__) && !defined(__MINGW64__)
+#if (defined(__linux__) || (defined(__APPLE__) && defined(__MACH__))) && !defined(__MINGW64__)
   // disable character echoing and line buffering
   struct termios tty_attr;
   if (tcgetattr(STDIN_FILENO, &tty_attr) < 0)
@@ -94,7 +94,7 @@ inline bool getPassword(std::string *pw)
   }
   PUTCHAR('\n');
 
-#if defined(__linux__) && !defined(__MINGW64__)
+#if (defined(__linux__) || (defined(__APPLE__) && defined(__MACH__))) && !defined(__MINGW64__)
   // restore terminal settings
   tty_attr.c_lflag = c_lflag;
 

--- a/sqlitedb/availablewidth.cc
+++ b/sqlitedb/availablewidth.cc
@@ -21,7 +21,7 @@
 
 int SqliteDB::QueryResults::availableWidth() const
 {
-#if defined(__linux__) && !defined(__MINGW64__)
+#if (defined(__linux__) || (defined(__APPLE__) && defined(__MACH__))) && !defined(__MINGW64__)
   struct winsize ts;
   if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &ts) != -1)
     return (ts.ws_col < 40) ? 40 : ts.ws_col;


### PR DESCRIPTION
Currently platform checks in the code only check for whether the system is Linux or Windows. This causes compilation failures on macOS in `main.h` since, e.g., `GETCHAR` and `PUTCHAR` don't get defined when compiling on macOS systems.

This PR replaces `defined(__linux__)` with `(defined(__linux__) || (defined(__APPLE__) && defined(__MACH__)))` throughout the code base, since all the Linux specific code is either required on macOS (`main.h`), or is applicable to macOS as well.

I've tested compilation of the executable for both Intel and Apple Silicon chips on macOS.

(See https://github.com/NixOS/nixpkgs/pull/185963)