### PR TITLE
fix: Add missing utf-8 charset in searchpage.html

### DIFF
--- a/signalbackup/htmlwritesearchpage.cc
+++ b/signalbackup/htmlwritesearchpage.cc
@@ -33,6 +33,7 @@ void SignalBackup::HTMLwriteSearchpage(std::string const &dir, bool light, bool 
     R"(<!DOCTYPE html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>Signal conversation search</title>
     <style>
 .searchresults {


### PR DESCRIPTION
Without setting the utf-8 charset, the rendering of emoticons and umlauts are broken in the search page view, even if the searchidx.js contains the data correctly.