### PR TITLE
Add missing webkit prefixes for icons

### DIFF
--- a/signalbackup/htmlwrite.cc
+++ b/signalbackup/htmlwrite.cc
@@ -1388,6 +1388,8 @@ bool SignalBackup::HTMLwriteStart(std::ofstream &file, long long int thread_reci
       .msg-status .msg-phone-icon,
       .msg-incoming .shared-contact-avatar-default,
       .msg-outgoing .shared-contact-avatar-default {
+        -webkit-print-color-adjust: exact;
+        color-adjust: exact;
         print-color-adjust: exact;
         filter: brightness(0.5);
       }


### PR DESCRIPTION
For some reason while all the other "color-adjust" statements this particular line was missing the -webkit prefixed version, resulting in a grey box icon in my chrome installation.